### PR TITLE
Fix build imports for analytics

### DIFF
--- a/web/src/archive/analytics/components/AddWidgetButton.tsx
+++ b/web/src/archive/analytics/components/AddWidgetButton.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
-import { AVAILABLE_WIDGETS } from '@/hooks/useAnalyticsDashboard'
+import { AVAILABLE_WIDGETS } from '@/archive/analytics/hooks/useAnalyticsDashboard'
 import { WidgetType } from '@/types'
 
 interface AddWidgetButtonProps {

--- a/web/src/archive/analytics/components/DashboardGrid.tsx
+++ b/web/src/archive/analytics/components/DashboardGrid.tsx
@@ -4,8 +4,8 @@ import { Plus } from "lucide-react"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 import { Button } from "@/components/ui/button"
 import { WidgetWrapper } from "./WidgetWrapper"
-import { AVAILABLE_WIDGETS } from "@/hooks/useAnalyticsDashboard"
-import type { WidgetType, WidgetSize, WidgetSettings } from "@/types/analytics"
+import { AVAILABLE_WIDGETS } from "@/archive/analytics/hooks/useAnalyticsDashboard"
+import type { WidgetType, WidgetSize, WidgetSettings } from "@/archive/analytics/types/analytics"
 
 interface DashboardGridProps {
   widgets: {

--- a/web/src/archive/analytics/components/WidgetWrapper.tsx
+++ b/web/src/archive/analytics/components/WidgetWrapper.tsx
@@ -3,10 +3,10 @@
 import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { X, GripHorizontal, Maximize2 } from "lucide-react"
-import type { Widget, WidgetSettings, WidgetSize } from "@/types/analytics"
+import type { Widget, WidgetSettings, WidgetSize } from "@/archive/analytics/types/analytics"
 import * as Widgets from "./widgets"
 import { DeleteWidgetDialog } from "./DeleteWidgetDialog"
-import { AVAILABLE_WIDGETS } from "@/hooks/useAnalyticsDashboard"
+import { AVAILABLE_WIDGETS } from "@/archive/analytics/hooks/useAnalyticsDashboard"
 import { ErrorBoundary } from "react-error-boundary"
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
 

--- a/web/src/archive/analytics/components/widgets/ProblemsSolvedWidget.tsx
+++ b/web/src/archive/analytics/components/widgets/ProblemsSolvedWidget.tsx
@@ -6,7 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { type ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { MOCK_PROBLEMS_SOLVED } from "@/lib/mock/analytics"
 import { useState, useEffect } from "react"
-import type { WidgetSize } from "@/types/analytics"
+import type { WidgetSize } from "@/archive/analytics/types/analytics"
 import { cn } from "@/lib/utils"
 import { format, parseISO } from "date-fns"
 
@@ -17,7 +17,7 @@ const chartConfig = {
   },
 } satisfies ChartConfig
 
-import type { TimeRangeOption, WidgetSettings } from "@/types/analytics"
+import type { TimeRangeOption, WidgetSettings } from "@/archive/analytics/types/analytics"
 
 interface ProblemsSolvedWidgetProps {
   settings?: WidgetSettings

--- a/web/src/archive/analytics/components/widgets/StudyTimeWidget.tsx
+++ b/web/src/archive/analytics/components/widgets/StudyTimeWidget.tsx
@@ -18,7 +18,7 @@ import {
   ChartTooltipContent,
 } from "@/components/ui/chart"
 import { MOCK_STUDY_TIME } from '@/lib/mock/analytics'
-import { WidgetSettings } from '@/types/analytics'
+import { WidgetSettings } from '@/archive/analytics/types/analytics'
 import { cn } from "@/lib/utils"
 
 interface StudyTimeWidgetProps {

--- a/web/src/archive/analytics/hooks/useAnalyticsDashboard.ts
+++ b/web/src/archive/analytics/hooks/useAnalyticsDashboard.ts
@@ -1,7 +1,7 @@
 'use client'
 
-import { useLocalStorage } from './useLocalStorage'
-import { Widget, WidgetType, WidgetSettings, WidgetSize } from '@/types/analytics'
+import { useLocalStorage } from '../../../hooks/useLocalStorage'
+import { Widget, WidgetType, WidgetSettings, WidgetSize } from '@/archive/analytics/types/analytics'
 
 export const AVAILABLE_WIDGETS: Record<WidgetType, {
   title: string

--- a/web/src/archive/analytics/pages/page.tsx
+++ b/web/src/archive/analytics/pages/page.tsx
@@ -1,12 +1,12 @@
 "use client"
 
 import { useEffect, useState, useRef } from "react"
-import { DashboardGrid } from "@/components/analytics/DashboardGrid"
-import { useAnalyticsDashboard } from "@/hooks/useAnalyticsDashboard"
+import { DashboardGrid } from "@/archive/analytics/components/DashboardGrid"
+import { useAnalyticsDashboard } from "@/archive/analytics/hooks/useAnalyticsDashboard"
 import { ArrowLeft, ChevronLeft, ChevronRight } from "lucide-react"
 import Link from "next/link"
 import { Button } from "@/components/ui/button"
-import type { WidgetType } from "@/types/analytics"
+import type { WidgetType } from "@/archive/analytics/types/analytics"
 
 export default function AnalyticsPage() {
   const [isClient, setIsClient] = useState(false)

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -11,4 +11,5 @@ export type ProblemWithTypedChoices = Omit<Prisma.ProblemGetPayload<{ select: { 
 
 export type Problem = ProblemWithTypedChoices
 
-export * from './analytics'
+export * from '../archive/analytics/types/analytics'
+


### PR DESCRIPTION
## Summary
- update imports for analytics dashboard code
- correct export path for analytics types

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f65adbc18832db9bcc8b96f6cdc83