### PR TITLE
Move exam selection to dashboard dialog

### DIFF
--- a/web/src/app/guided-practice/page.tsx
+++ b/web/src/app/guided-practice/page.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState, useEffect } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Button } from '@/components/ui/button'
 import { Progress } from '@/components/ui/progress'
 import PracticeProblem from './components/PracticeProblem'
@@ -21,6 +21,7 @@ export default function GuidedPracticePage() {
   const [error, setError] = useState<string | null>(null)
   const [userExams, setUserExams] = useState<string[]>([])
   const [selectedExam, setSelectedExam] = useState<string>('')
+  const searchParams = useSearchParams()
   
   useEffect(() => {
     async function fetchUserData() {
@@ -40,7 +41,12 @@ export default function GuidedPracticePage() {
           return
         }
         
-        if (exams.length === 1) {
+        const examParam = searchParams.get('exam')
+
+        if (examParam && exams.includes(examParam)) {
+          setSelectedExam(examParam)
+          startSession(examParam)
+        } else if (exams.length === 1) {
           setSelectedExam(exams[0])
           startSession(exams[0])
         } else {
@@ -55,7 +61,7 @@ export default function GuidedPracticePage() {
     }
     
     fetchUserData()
-  }, [])
+  }, [searchParams])
   
   const startSession = async (examType: string) => {
     setLoading(true)

--- a/web/src/app/home/components/PracticeExamDialog.tsx
+++ b/web/src/app/home/components/PracticeExamDialog.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export default function PracticeExamDialog({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [exams, setExams] = useState<string[]>([])
+  const [selectedExam, setSelectedExam] = useState('')
+
+  const handleTriggerClick = async () => {
+    setLoading(true)
+    try {
+      const res = await fetch('/api/profile')
+      const data = await res.json()
+      const examTypes = data.examRegistrations?.map((reg: { examType: string }) => reg.examType) || []
+
+      if (examTypes.length === 0) {
+        router.push('/setup')
+        return
+      }
+
+      if (examTypes.length === 1) {
+        router.push(`/guided-practice?exam=${encodeURIComponent(examTypes[0])}`)
+        return
+      }
+
+      setExams(examTypes)
+      setOpen(true)
+    } catch (err) {
+      console.error('Failed to load exams:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const startPractice = () => {
+    if (!selectedExam) return
+    router.push(`/guided-practice?exam=${encodeURIComponent(selectedExam)}`)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <span onClick={handleTriggerClick} className="contents">
+          {children}
+        </span>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Which exam would you like to study for?</DialogTitle>
+        </DialogHeader>
+        {loading ? (
+          <div className="space-y-4">
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : (
+          <div className="space-y-4">
+            <Select value={selectedExam} onValueChange={setSelectedExam}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Select an exam" />
+              </SelectTrigger>
+              <SelectContent>
+                {exams.map((exam) => (
+                  <SelectItem key={exam} value={exam}>
+                    Exam {exam}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button onClick={startPractice} disabled={!selectedExam} className="w-full">
+              Start Practice
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/web/src/app/home/page.tsx
+++ b/web/src/app/home/page.tsx
@@ -13,6 +13,7 @@ import {
 import Link from 'next/link';
 import { getRequiredServerSession } from '@/lib/auth/server';
 import { format, addDays } from 'date-fns';
+import PracticeExamDialog from './components/PracticeExamDialog';
 
 export default async function HomePage() {
   const session = await getRequiredServerSession();
@@ -44,12 +45,12 @@ export default async function HomePage() {
             </div>
             
             <div className="flex gap-4 mt-2 md:mt-0">
-              <Link href="/guided-practice">
+              <PracticeExamDialog>
                 <Button className="gap-2 bg-primary hover:bg-primary-dark">
                   <Compass className="h-4 w-4" />
                   Start Practice
                 </Button>
-              </Link>
+              </PracticeExamDialog>
               <Link href="/analytics">
                 <Button variant="outline" className="gap-2 border-border">
                   <BarChart className="h-4 w-4" />
@@ -72,16 +73,18 @@ export default async function HomePage() {
               </div>
             </div>
             
-            <Button variant="outline" size="sm" className="gap-2 border-primary/20 text-primary hover:bg-primary/5">
-              <Compass className="h-4 w-4" />
-              Continue Practice
-            </Button>
+            <PracticeExamDialog>
+              <Button variant="outline" size="sm" className="gap-2 border-primary/20 text-primary hover:bg-primary/5">
+                <Compass className="h-4 w-4" />
+                Continue Practice
+              </Button>
+            </PracticeExamDialog>
           </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mb-6">
-          <Link href="/guided-practice" className="group">
-            <Card className="hover:shadow-md bg-background-highlight border-border transition-all duration-200 h-full overflow-hidden group-hover:border-primary/50">
+          <PracticeExamDialog>
+            <Card className="hover:shadow-md bg-background-highlight border-border transition-all duration-200 h-full overflow-hidden group-hover:border-primary/50 cursor-pointer">
               <CardHeader className="pb-2">
                 <CardTitle className="flex items-center gap-2 text-lg">
                   <div className="p-2 rounded-full bg-primary/10 text-primary">
@@ -99,7 +102,7 @@ export default async function HomePage() {
                 </div>
               </CardContent>
             </Card>
-          </Link>
+          </PracticeExamDialog>
 
           <Link href="/questions" className="group">
             <Card className="hover:shadow-md bg-background-highlight border-border transition-all duration-200 h-full overflow-hidden group-hover:border-primary/50">


### PR DESCRIPTION
## Summary
- add PracticeExamDialog component
- launch exam selection from Home buttons
- allow guided practice to start via query param

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f97d180c4832da319909fd31340a8