### PR TITLE
Remove debug fonts from question page

### DIFF
--- a/web/src/app/questions/page.tsx
+++ b/web/src/app/questions/page.tsx
@@ -336,7 +336,7 @@ export default function QuestionsPage() {
         <CardContent className="p-6">
           <div className="flex gap-6">
             <div className="flex-1">
-              <div className="prose max-w-none !font-serif text-foreground [&_table]:w-auto [&_table]:border-collapse [&_table]:my-4 [&_th]:border [&_th]:border-border [&_th]:bg-background-secondary [&_th]:p-2 [&_th]:text-left [&_td]:border [&_td]:border-border [&_td]:p-2 [&_th]:text-sm [&_td]:text-sm [&_table]:mx-auto [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:space-y-2 [&_ol]:my-4 debug-fonts">
+              <div className="prose max-w-none !font-serif text-foreground [&_table]:w-auto [&_table]:border-collapse [&_table]:my-4 [&_th]:border [&_th]:border-border [&_th]:bg-background-secondary [&_th]:p-2 [&_th]:text-left [&_td]:border [&_td]:border-border [&_td]:p-2 [&_th]:text-sm [&_td]:text-sm [&_table]:mx-auto [&_ol]:list-decimal [&_ol]:pl-6 [&_ol]:space-y-2 [&_ol]:my-4">
                 <MDXRemote {...serializedContent} />
               </div>
             </div>
@@ -354,7 +354,7 @@ export default function QuestionsPage() {
                 >
                   <div className="flex">
                     <span className="font-medium !font-serif mr-2 min-w-[1.5rem]">{choice.letter})</span>
-                    <div className="flex-1 !font-serif debug-fonts">
+                    <div className="flex-1 !font-serif">
                       {serializedChoices[index] && <MDXRemote {...serializedChoices[index]} />}
                     </div>
                   </div>


### PR DESCRIPTION
## Summary
- removed `debug-fonts` class from question page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa5b33368832dbde39b5f27812b4d