### PR TITLE
Add global error handling pages

### DIFF
--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-6 text-center">
+      <h2 className="text-3xl font-serif font-bold text-foreground mb-4">
+        Something went wrong
+      </h2>
+      <p className="text-foreground-secondary mb-8">
+        An unexpected error has occurred.
+      </p>
+      <div className="flex gap-4">
+        <Button variant="outline" onClick={reset}>
+          Try Again
+        </Button>
+        <Link href="/">
+          <Button variant="primary">Go Home</Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-background p-6 text-center">
+      <h2 className="text-4xl font-serif font-bold text-foreground mb-4">
+        404 - Page Not Found
+      </h2>
+      <p className="text-foreground-secondary mb-8">
+        Sorry, we couldn&#39;t find the page you were looking for.
+      </p>
+      <Link href="/">
+        <Button variant="primary" className="px-6">
+          Go to Home
+        </Button>
+      </Link>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `not-found.tsx` page to show a helpful 404 message
- add `error.tsx` root component for graceful error handling

## Testing
- `npm test --silent`
- `npm run lint --silent`


------
https://chatgpt.com/codex/tasks/task_e_683fa9e85040832db9b12cc50fd941f4