### PR TITLE
Add validated env loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ todo:
     - start testing on other
 - dark mode (gruvbox dark medium)
 - make a proper README
+
+## Environment Variables
+
+Configuration values for the web app are loaded and validated in
+`web/src/lib/env.ts`. Create a `.env` file by copying `web/.env.example`
+and update the values before starting development.

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,7 @@
+# Example environment configuration for local development
+# Copy this file to .env and update the values
+
+DATABASE_URL="postgresql://user:password@localhost:5432/openactuaries"
+DIRECT_URL="postgresql://user:password@localhost:5432/openactuaries?schema=public"
+NEXTAUTH_SECRET="changeme"
+NEXTAUTH_URL="http://localhost:3000"

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/web/src/lib/db/index.ts
+++ b/web/src/lib/db/index.ts
@@ -1,7 +1,8 @@
-import { PrismaClient } from '@prisma/client';
+import { PrismaClient } from '@prisma/client'
+import { NODE_ENV } from '@/lib/env'
 
 const globalForPrisma = global as unknown as { prisma: PrismaClient };
 
-export const prisma = globalForPrisma.prisma || new PrismaClient();
+export const prisma = globalForPrisma.prisma || new PrismaClient()
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+if (NODE_ENV !== 'production') globalForPrisma.prisma = prisma

--- a/web/src/lib/env.ts
+++ b/web/src/lib/env.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod'
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().url(),
+  DIRECT_URL: z.string().url(),
+  NEXTAUTH_SECRET: z.string(),
+  NEXTAUTH_URL: z.string().url().optional(),
+  NODE_ENV: z.enum(['development', 'test', 'production']).default('development'),
+})
+
+const env = envSchema.parse({
+  DATABASE_URL: process.env.DATABASE_URL,
+  DIRECT_URL: process.env.DIRECT_URL,
+  NEXTAUTH_SECRET: process.env.NEXTAUTH_SECRET,
+  NEXTAUTH_URL: process.env.NEXTAUTH_URL,
+  NODE_ENV: process.env.NODE_ENV,
+})
+
+export const {
+  DATABASE_URL,
+  DIRECT_URL,
+  NEXTAUTH_SECRET,
+  NEXTAUTH_URL,
+  NODE_ENV,
+} = env
+
+export default env


### PR DESCRIPTION
## Summary
- validate environment variables with zod
- export validated values through a new module
- use `NODE_ENV` from the module in the Prisma client
- keep `.env.example` under version control
- mention env loader in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa9c5d544832da1fbab5d212b4d17