### PR TITLE
Add zod schema validation to API routes

### DIFF
--- a/web/__tests__/api.practice.recommended.test.ts
+++ b/web/__tests__/api.practice.recommended.test.ts
@@ -1,66 +1,96 @@
 /**
  * @jest-environment node
  */
-import { POST } from '@/app/api/practice/recommended/route'
-import { prisma } from '@/lib/db'
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth/auth'
+import { POST } from '@/app/api/practice/recommended/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
 
 jest.mock('next-auth', () => ({
   getServerSession: jest.fn(),
-}))
+}));
 
 jest.mock('@/lib/auth/auth', () => ({
   authOptions: {},
-}))
+}));
 
 jest.mock('@/lib/db', () => ({
   prisma: {
     userProfile: { findUnique: jest.fn() },
     problem: { findMany: jest.fn() },
   },
-}))
+}));
 
 describe('POST /api/practice/recommended', () => {
   afterEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+  });
 
   it('returns 401 when not authenticated', async () => {
-    ;(getServerSession as jest.Mock).mockResolvedValue(null)
+    (getServerSession as jest.Mock).mockResolvedValue(null);
 
-    const request = new Request('http://localhost/api/practice/recommended', { method: 'POST' })
-    const response = await POST(request)
+    const request = new Request('http://localhost/api/practice/recommended', {
+      method: 'POST',
+    });
+    const response = await POST(request);
 
-    expect(response.status).toBe(401)
-    await expect(response.json()).resolves.toEqual({ error: 'Not authenticated' })
-  })
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
 
   it('returns recommended problems', async () => {
-    ;(getServerSession as jest.Mock).mockResolvedValue({ user: { id: 'user1' } })
-    ;(prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ problemAttempts: [{ problemId: 1 }] })
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { id: 'user1' },
+    });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({
+      problemAttempts: [{ problemId: 1 }],
+    });
 
-    const firstCall = [{ id: 2 }, { id: 3 }]
-    const secondCall = [{ id: 4 }]
-    ;(prisma.problem.findMany as jest.Mock)
+    const firstCall = [{ id: 2 }, { id: 3 }];
+    const secondCall = [{ id: 4 }];
+    (prisma.problem.findMany as jest.Mock)
       .mockResolvedValueOnce(firstCall)
-      .mockResolvedValueOnce(secondCall)
+      .mockResolvedValueOnce(secondCall);
 
     const request = new Request('http://localhost/api/practice/recommended', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ problemCount: 3, examType: 'P' }),
-    })
+    });
 
-    const originalRandom = Math.random
-    Math.random = jest.fn(() => 0.5)
+    const originalRandom = Math.random;
+    Math.random = jest.fn(() => 0.5);
 
-    const response = await POST(request)
+    const response = await POST(request);
 
-    Math.random = originalRandom
+    Math.random = originalRandom;
 
-    expect(prisma.problem.findMany).toHaveBeenCalledTimes(2)
-    expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual([...firstCall, ...secondCall])
-  })
-})
+    expect(prisma.problem.findMany).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual([
+      ...firstCall,
+      ...secondCall,
+    ]);
+  });
+
+  it('returns 400 on invalid body', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { id: 'user1' },
+    });
+
+    const request = new Request('http://localhost/api/practice/recommended', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ problemCount: 'abc' }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ error: expect.any(Object) }),
+    );
+  });
+});

--- a/web/__tests__/api.profile.setup.test.ts
+++ b/web/__tests__/api.profile.setup.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '@/app/api/profile/setup/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+    userProfile: { upsert: jest.fn() },
+    examRegistration: { deleteMany: jest.fn(), create: jest.fn() },
+  },
+}));
+
+describe('POST /api/profile/setup', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/profile/setup', {
+      method: 'POST',
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 400 on invalid body', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { email: 'a@b.com', id: '1' },
+    });
+
+    const request = new Request('http://localhost/api/profile/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ error: expect.any(Object) }),
+    );
+  });
+});

--- a/web/__tests__/api.register.test.ts
+++ b/web/__tests__/api.register.test.ts
@@ -1,9 +1,9 @@
 /**
  * @jest-environment node
  */
-import { POST } from '@/app/api/register/route'
-import { prisma } from '@/lib/db'
-import bcrypt from 'bcryptjs'
+import { POST } from '@/app/api/register/route';
+import { prisma } from '@/lib/db';
+import bcrypt from 'bcryptjs';
 
 jest.mock('@/lib/db', () => ({
   prisma: {
@@ -12,57 +12,80 @@ jest.mock('@/lib/db', () => ({
       create: jest.fn(),
     },
   },
-}))
+}));
 
 jest.mock('bcryptjs', () => ({
   hash: jest.fn(() => 'hashedPassword'),
-}))
+}));
 
 describe('POST /api/register', () => {
-  const userData = { name: 'John Doe', email: 'john@example.com', password: 'secret' }
+  const userData = {
+    name: 'John Doe',
+    email: 'john@example.com',
+    password: 'secret',
+  };
 
   afterEach(() => {
-    jest.clearAllMocks()
-  })
+    jest.clearAllMocks();
+  });
 
   it('returns 400 if email already exists', async () => {
-    ;(prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: '1' })
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: '1' });
 
     const request = new Request('http://localhost/api/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(userData),
-    })
+    });
 
-    const response = await POST(request)
+    const response = await POST(request);
 
-    expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toEqual({ error: 'Email already in use' })
-    expect(prisma.user.create).not.toHaveBeenCalled()
-  })
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Email already in use',
+    });
+    expect(prisma.user.create).not.toHaveBeenCalled();
+  });
 
   it('creates user and returns 201', async () => {
-    ;(prisma.user.findUnique as jest.Mock).mockResolvedValue(null)
-    ;(prisma.user.create as jest.Mock).mockResolvedValue({ id: '1' })
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+    (prisma.user.create as jest.Mock).mockResolvedValue({ id: '1' });
 
     const request = new Request('http://localhost/api/register', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(userData),
-    })
+    });
 
-    const response = await POST(request)
+    const response = await POST(request);
 
-    expect(bcrypt.hash).toHaveBeenCalledWith(userData.password, 10)
+    expect(bcrypt.hash).toHaveBeenCalledWith(userData.password, 10);
     expect(prisma.user.create).toHaveBeenCalledWith({
       data: {
         name: userData.name,
         email: userData.email,
         password: 'hashedPassword',
       },
-    })
+    });
 
-    expect(response.status).toBe(201)
-    await expect(response.json()).resolves.toEqual({ message: 'User created successfully' })
-  })
-})
+    expect(response.status).toBe(201);
+    await expect(response.json()).resolves.toEqual({
+      message: 'User created successfully',
+    });
+  });
+
+  it('returns 400 when body fails validation', async () => {
+    const request = new Request('http://localhost/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ error: expect.any(Object) }),
+    );
+  });
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -47,7 +47,8 @@
         "remark-math": "^6.0.0",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
-        "vaul": "^1.1.2"
+        "vaul": "^1.1.2",
+        "zod": "^3.25.50"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -15830,6 +15831,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.50",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.50.tgz",
+      "integrity": "sha512-VstOnRxf4tlSq0raIwbn0n+LA34SxVoZ8r3pkwSUM0jqNiA/HCMQEVjTuS5FZmHsge+9MDGTiAuHyml5T0um6A==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/web/package.json
+++ b/web/package.json
@@ -53,7 +53,8 @@
     "remark-math": "^6.0.0",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",
-    "vaul": "^1.1.2"
+    "vaul": "^1.1.2",
+    "zod": "^3.25.50"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/web/src/app/api/register/route.ts
+++ b/web/src/app/api/register/route.ts
@@ -1,10 +1,26 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/db';
 import bcrypt from 'bcryptjs';
+import { z } from 'zod';
+
+const registerSchema = z.object({
+  name: z.string().min(1, 'Name is required'),
+  email: z.string().email('Invalid email address'),
+  password: z.string().min(6, 'Password must be at least 6 characters'),
+});
 
 export async function POST(request: Request) {
   try {
-    const { name, email, password } = await request.json();
+    const body = await request.json();
+    const parsed = registerSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten().fieldErrors },
+        { status: 400 },
+      );
+    }
+
+    const { name, email, password } = parsed.data;
 
     const existingUser = await prisma.user.findUnique({
       where: {


### PR DESCRIPTION
## Summary
- install zod in `web`
- validate request bodies in register, profile setup and practice recommended routes
- send detailed 400 responses when validation fails
- add tests for new validation logic

## Testing
- `npm run format`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fa9ca90e8832da66cd5d7d38d3685