### PR TITLE
Add CI workflow for web app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
       - name: Install dependencies
-        run: npm ci
+        run: npm install --force
       - name: Lint
         run: npm run lint
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+defaults:
+  run:
+    working-directory: web
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -11,3 +11,6 @@ todo:
     - start testing on other
 - dark mode (gruvbox dark medium)
 - make a proper README
+## Continuous Integration
+
+A GitHub Actions workflow (`ci.yml`) installs dependencies, runs `npm run lint`, and executes `npm test` inside `web/`. Node modules are cached to speed up runs.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to lint and test the Next.js app
- mention the workflow in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_683fadafa6f4832d8f453bd0688f2680