### PR TITLE
Add tests for profile and practice APIs

### DIFF
--- a/web/__tests__/api.practice.save-session.test.ts
+++ b/web/__tests__/api.practice.save-session.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @jest-environment node
+ */
+import { POST } from '@/app/api/practice/save-session/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+    studySession: { create: jest.fn() },
+    problemAttempt: { create: jest.fn() },
+  },
+}));
+
+describe('POST /api/practice/save-session', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/practice/save-session', {
+      method: 'POST',
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when user profile missing', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/practice/save-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ problems: [], answers: [] }),
+    });
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'User profile not found',
+    });
+  });
+
+  it('saves session and attempts', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'p1' });
+    (prisma.studySession.create as jest.Mock).mockResolvedValue({ id: 's1' });
+
+    const answers = [
+      { problemId: 'a', answer: '1', isCorrect: true, timeSpent: 30 },
+      { problemId: 'b', answer: '2', isCorrect: false, timeSpent: 40 },
+    ];
+
+    const request = new Request('http://localhost/api/practice/save-session', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ problems: [], answers }),
+    });
+
+    const response = await POST(request);
+
+    expect(prisma.studySession.create).toHaveBeenCalledTimes(1);
+    expect(prisma.problemAttempt.create).toHaveBeenCalledTimes(2);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      sessionId: 's1',
+    });
+  });
+});

--- a/web/__tests__/api.profile.setup.test.ts
+++ b/web/__tests__/api.profile.setup.test.ts
@@ -59,4 +59,68 @@ describe('POST /api/profile/setup', () => {
       expect.objectContaining({ error: expect.any(Object) }),
     );
   });
+
+  it('returns 404 when user not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { email: 'a@b.com', id: '1' },
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/profile/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        goalType: 'Exam',
+        goalAmount: 5,
+        examRegistrations: [],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'User not found',
+    });
+  });
+
+  it('saves profile and exams', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { email: 'a@b.com', id: '1' },
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({ id: '1' });
+    (prisma.userProfile.upsert as jest.Mock).mockResolvedValue({ id: 'p1' });
+
+    const request = new Request('http://localhost/api/profile/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        goalType: 'Exam',
+        goalAmount: 5,
+        examRegistrations: [
+          { exam: 'P', date: '2023-01-01T00:00:00.000Z' },
+        ],
+      }),
+    });
+
+    const response = await POST(request);
+
+    expect(prisma.userProfile.upsert).toHaveBeenCalledWith({
+      where: { userId: '1' },
+      update: { goalType: 'Exam', goalAmount: 5 },
+      create: { userId: '1', goalType: 'Exam', goalAmount: 5 },
+    });
+    expect(prisma.examRegistration.deleteMany).toHaveBeenCalledWith({
+      where: { profileId: 'p1' },
+    });
+    expect(prisma.examRegistration.create).toHaveBeenCalledWith({
+      data: {
+        profileId: 'p1',
+        examType: 'P',
+        examDate: new Date('2023-01-01T00:00:00.000Z'),
+      },
+    });
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ success: true });
+  });
 });

--- a/web/__tests__/api.profile.test.ts
+++ b/web/__tests__/api.profile.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/profile/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    user: { findUnique: jest.fn() },
+  },
+}));
+
+describe('GET /api/profile', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when user not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { email: 'a@b.com' },
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(prisma.user.findUnique).toHaveBeenCalledWith({
+      where: { email: 'a@b.com' },
+      include: {
+        profile: {
+          include: { examRegistrations: true },
+        },
+      },
+    });
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'User not found',
+    });
+  });
+
+  it('returns defaults when profile missing', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { email: 'a@b.com' },
+    });
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: '1',
+      profile: null,
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      goalType: null,
+      goalAmount: null,
+      examRegistrations: [],
+    });
+  });
+
+  it('returns profile when found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({
+      user: { email: 'a@b.com' },
+    });
+    const profile = {
+      id: 'p1',
+      goalType: 'Exam',
+      goalAmount: 10,
+      examRegistrations: [{ id: 1 }],
+    };
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: '1',
+      profile,
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(profile);
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for profile GET API
- extend profile setup tests
- test practice save-session endpoint

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fadb3bcf8832da7c19b81ffab7dd7