### PR TITLE
Add analytics API tests

### DIFF
--- a/web/__tests__/api.analytics.history.test.ts
+++ b/web/__tests__/api.analytics.history.test.ts
@@ -1,0 +1,69 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/history/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+    problemAttempt: { findMany: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/history', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns history analytics', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-15T12:00:00Z'));
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'p1' });
+    (prisma.problemAttempt.findMany as jest.Mock).mockResolvedValue([]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(Array.isArray(json.accuracyHistory)).toBe(true);
+    expect(Array.isArray(json.volumeHistory)).toBe(true);
+    expect(Array.isArray(json.recentProblems)).toBe(true);
+    expect(json.accuracyHistory).toHaveLength(12);
+    expect(json.volumeHistory).toHaveLength(12);
+  });
+});

--- a/web/__tests__/api.analytics.overview.test.ts
+++ b/web/__tests__/api.analytics.overview.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/overview/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/overview', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns overview stats', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({
+      problemAttempts: [{ isCorrect: true }, { isCorrect: false }],
+      studySessions: [{ minutesSpent: 30 }, { minutesSpent: 60 }],
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      totalProblemsSolved: 2,
+      totalStudyHours: 2,
+      accuracy: 50,
+    });
+  });
+});

--- a/web/__tests__/api.analytics.time.test.ts
+++ b/web/__tests__/api.analytics.time.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/time/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+    studySession: { findMany: jest.fn() },
+    problemAttempt: { findMany: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/time', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns time analytics', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2023-05-15T12:00:00Z'));
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'p1' });
+    (prisma.studySession.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.problemAttempt.findMany as jest.Mock).mockResolvedValue([]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(Array.isArray(json.weekdayDistribution)).toBe(true);
+    expect(Array.isArray(json.studyDates)).toBe(true);
+    expect(Array.isArray(json.timePerformance)).toBe(true);
+    expect(json.weeklyReport).toEqual(
+      expect.objectContaining({
+        problems: expect.any(Object),
+        studyHours: expect.any(Object),
+        accuracy: expect.any(Object),
+      }),
+    );
+    expect(json.streak).toEqual(
+      expect.objectContaining({
+        currentStreak: expect.any(Number),
+        longestStreak: expect.any(Number),
+        monthDays: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/web/__tests__/api.analytics.topics.test.ts
+++ b/web/__tests__/api.analytics.topics.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/topics/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+    problemAttempt: { findMany: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/topics', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/analytics/topics');
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/analytics/topics');
+    const response = await GET(request);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns topic stats', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'p1' });
+    (prisma.problemAttempt.findMany as jest.Mock).mockResolvedValue([
+      { isCorrect: true, problem: { syllabusCategory: 'Alg' } },
+      { isCorrect: false, problem: { syllabusCategory: 'Calc' } },
+      { isCorrect: true, problem: { syllabusCategory: 'Alg' } },
+    ]);
+
+    const request = new Request('http://localhost/api/analytics/topics?exam=P');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      breakdown: [
+        { topic: 'Alg', value: 2 },
+        { topic: 'Calc', value: 1 },
+      ],
+      performance: [
+        { subject: 'Alg', accuracy: 100 },
+        { subject: 'Calc', accuracy: 0 },
+      ],
+      toFocus: [{ topic: 'Calc', accuracy: 0, problems: 1 }],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for analytics API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb9867c78832d863d00518ad5f315