### PR TITLE
Add analytics API test coverage

### DIFF
--- a/web/__tests__/api.analytics.history.test.ts
+++ b/web/__tests__/api.analytics.history.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/history/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+    problemAttempt: { findMany: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/history', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns history analytics', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'p1' });
+    (prisma.problemAttempt.findMany as jest.Mock)
+      .mockResolvedValueOnce([
+        {
+          createdAt: new Date(),
+          isCorrect: true,
+          problem: { exam: 'P', syllabusCategory: 'A', questionNumber: 1 },
+          timeSpent: 30,
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: 'a1',
+          createdAt: new Date(),
+          isCorrect: true,
+          timeSpent: 30,
+          problem: { exam: 'P', syllabusCategory: 'A', questionNumber: 1 },
+        },
+      ]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(Array.isArray(data.accuracyHistory)).toBe(true);
+    expect(Array.isArray(data.volumeHistory)).toBe(true);
+    expect(Array.isArray(data.recentProblems)).toBe(true);
+  });
+});

--- a/web/__tests__/api.analytics.overview.test.ts
+++ b/web/__tests__/api.analytics.overview.test.ts
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/overview/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/overview', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(prisma.userProfile.findUnique).toHaveBeenCalledWith({
+      where: { userId: '1' },
+      include: { problemAttempts: true, studySessions: true },
+    });
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns overview stats', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({
+      problemAttempts: [
+        { isCorrect: true },
+        { isCorrect: false },
+      ],
+      studySessions: [
+        { minutesSpent: 30 },
+        { minutesSpent: 90 },
+      ],
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      totalProblemsSolved: 2,
+      totalStudyHours: 2,
+      accuracy: 50,
+    });
+  });
+});

--- a/web/__tests__/api.analytics.time.test.ts
+++ b/web/__tests__/api.analytics.time.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/time/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+    studySession: { findMany: jest.fn() },
+    problemAttempt: { findMany: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/time', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns time analytics', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    const now = new Date();
+    const lastWeek = new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000);
+    const prevWeek = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000);
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'p1' });
+    (prisma.studySession.findMany as jest.Mock).mockResolvedValue([
+      { startTime: lastWeek, minutesSpent: 60 },
+      { startTime: prevWeek, minutesSpent: 30 },
+    ]);
+    (prisma.problemAttempt.findMany as jest.Mock).mockResolvedValue([
+      { createdAt: lastWeek, isCorrect: true, studySession: { startTime: lastWeek } },
+      { createdAt: prevWeek, isCorrect: false, studySession: { startTime: prevWeek } },
+    ]);
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const data = await response.json();
+
+    expect(Array.isArray(data.weekdayDistribution)).toBe(true);
+    expect(Array.isArray(data.studyDates)).toBe(true);
+    expect(Array.isArray(data.timePerformance)).toBe(true);
+    expect(typeof data.weeklyReport).toBe('object');
+    expect(typeof data.streak).toBe('object');
+  });
+});

--- a/web/__tests__/api.analytics.topics.test.ts
+++ b/web/__tests__/api.analytics.topics.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+import { GET } from '@/app/api/analytics/topics/route';
+import { prisma } from '@/lib/db';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth/auth';
+
+jest.mock('next-auth', () => ({
+  getServerSession: jest.fn(),
+}));
+
+jest.mock('@/lib/auth/auth', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/db', () => ({
+  prisma: {
+    userProfile: { findUnique: jest.fn() },
+    problemAttempt: { findMany: jest.fn() },
+  },
+}));
+
+describe('GET /api/analytics/topics', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/analytics/topics');
+    const response = await GET(request);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Not authenticated',
+    });
+  });
+
+  it('returns 404 when profile not found', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const request = new Request('http://localhost/api/analytics/topics');
+    const response = await GET(request);
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Profile not found',
+    });
+  });
+
+  it('returns topic analytics', async () => {
+    (getServerSession as jest.Mock).mockResolvedValue({ user: { id: '1' } });
+    (prisma.userProfile.findUnique as jest.Mock).mockResolvedValue({ id: 'p1' });
+    (prisma.problemAttempt.findMany as jest.Mock).mockResolvedValue([
+      { isCorrect: true, problem: { syllabusCategory: 'A' } },
+      { isCorrect: false, problem: { syllabusCategory: 'A' } },
+      { isCorrect: true, problem: { syllabusCategory: 'B' } },
+    ]);
+
+    const request = new Request('http://localhost/api/analytics/topics');
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      breakdown: [
+        { topic: 'A', value: 2 },
+        { topic: 'B', value: 1 },
+      ],
+      performance: [
+        { subject: 'A', accuracy: 50 },
+        { subject: 'B', accuracy: 100 },
+      ],
+      toFocus: [
+        { topic: 'A', accuracy: 50, problems: 2 },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for analytics endpoints (overview, topics, time, history)
- mock NextAuth and Prisma in new API tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fb97113ec832daed45255fe7e1f4f