### PR TITLE
Add Playwright-based e2e test framework

### DIFF
--- a/web/e2e/landing.spec.ts
+++ b/web/e2e/landing.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('landing page loads', async ({ page }) => {
+  await page.goto('/');
+  await expect(page).toHaveTitle(/open\/actuaries/i);
+  await expect(page.getByRole('heading', { level: 1 })).toContainText('Actuarial');
+});

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -14,6 +14,7 @@ const customJestConfig = {
       '<rootDir>/node_modules/lucide-react/dist/cjs/lucide-react.js',
   },
   transformIgnorePatterns: ['/node_modules/(?!(lucide-react)/)'],
+  testPathIgnorePatterns: ['<rootDir>/e2e/'],
 };
 
 module.exports = createJestConfig(customJestConfig);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -53,6 +53,7 @@
       "devDependencies": {
         "@eslint/eslintrc": "^3",
         "@faker-js/faker": "^9.4.0",
+        "@playwright/test": "^1.52.0",
         "@testing-library/dom": "^9.3.4",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
@@ -2312,6 +2313,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@prisma/client": {
@@ -12333,6 +12350,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "seed:test": "ts-node --project tsconfig.scripts.json scripts/seed-test-data.ts",
     "seed:all": "npm run seed:problems && npm run seed:test",
     "test": "jest",
+    "test:e2e": "playwright test",
     "format": "prettier --write ."
   },
   "dependencies": {
@@ -59,6 +60,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "@faker-js/faker": "^9.4.0",
+    "@playwright/test": "^1.52.0",
     "@testing-library/dom": "^9.3.4",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
@@ -73,10 +75,10 @@
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "postcss": "^8",
+    "prettier": "^3.5.3",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
-    "typescript": "^5.7.3",
-    "prettier": "^3.5.3"
+    "typescript": "^5.7.3"
   }
 }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+    cwd: '.',
+  },
+  use: {
+    baseURL: 'http://localhost:3000',
+    headless: true,
+  },
+});


### PR DESCRIPTION
## Summary
- add Playwright dev dependency and test:e2e script
- configure Playwright to launch Next.js dev server
- ignore e2e folder in Jest
- provide first landing page e2e test

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_683fbb298844832d884ef4f0c12b151d